### PR TITLE
Eliminated use of Inkscape

### DIFF
--- a/bin/certificates.py
+++ b/bin/certificates.py
@@ -50,6 +50,7 @@ import unicodedata
 from optparse import OptionParser
 import time
 from datetime import date
+import cairosvg
 
 
 DATE_FORMAT = '%B %-d, %Y'
@@ -161,11 +162,7 @@ def create_certificate(inkscape_path, template_path, output_path, params):
     tmp = tempfile.NamedTemporaryFile(suffix='.svg', delete=False)
     tmp.write(bytes(template, 'utf-8'))
 
-    subprocess.call([inkscape_path,
-                     '--export-pdf', output_path,
-                     tmp.name,
-                     '--export-dpi', '600'])
-
+    cairosvg.svg2pdf(url=tmp.name, write_to=output_path, dpi=600)
 
 
 def check_template(template, params):

--- a/bin/certificates.py
+++ b/bin/certificates.py
@@ -167,7 +167,7 @@ def create_certificate(template_path, output_path, params):
     tmp = tempfile.NamedTemporaryFile(suffix='.svg', delete=False)
     tmp.write(bytes(template, 'utf-8'))
 
-    cairosvg.svg2pdf(url=tmp.name, write_to=output_path, dpi=1200)
+    cairosvg.svg2pdf(url=tmp.name, write_to=output_path, dpi=90)
 
 
 def check_template(template, params):

--- a/bin/certificates.py
+++ b/bin/certificates.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python
 
 '''
-Generate a certificate from a template.  On a Mac, a typical command line is
+Generate a certificate from a template.
+
+* Requires the python package 'cairosvg' to be installed.
+  Please visit http://cairosvg.org/ for install instructions.
+* Some systems may also need to have 'cairo' installed.
+  Please visit http://cairographics.org/download/ for the same.
+
+On a Mac, a typical command line is
 
 python bin/certificates.py \
        -b swc-instructor
@@ -160,7 +167,7 @@ def create_certificate(template_path, output_path, params):
     tmp = tempfile.NamedTemporaryFile(suffix='.svg', delete=False)
     tmp.write(bytes(template, 'utf-8'))
 
-    cairosvg.svg2pdf(url=tmp.name, write_to=output_path, dpi=600)
+    cairosvg.svg2pdf(url=tmp.name, write_to=output_path, dpi=1200)
 
 
 def check_template(template, params):

--- a/bin/certificates.py
+++ b/bin/certificates.py
@@ -4,7 +4,6 @@
 Generate a certificate from a template.  On a Mac, a typical command line is
 
 python bin/certificates.py \
-       -i /Applications/Inkscape.app/Contents/Resources/bin/inkscape \
        -b swc-instructor
        -r $HOME/sc/certification/ \
        -u turing_alan
@@ -14,7 +13,6 @@ python bin/certificates.py \
 
 where:
 
-    -i:         INKSCAPE_NAME (optional)
     -b:         BADGE_TYPE
     -r:         ROOT_DIRECTORY
     -u:         USER_ID
@@ -34,7 +32,6 @@ such as:
 In this case, the command line invocation is:
 
 python bin/certificates.py \
-       -i /Applications/Inkscape.app/Contents/Resources/bin/inkscape \
        -r $HOME/sc/certification/ \
        -c input.csv
        instructor='Ada Lovelace'
@@ -68,10 +65,12 @@ def parse_args():
     '''Get command-line arguments.'''
 
     parser = OptionParser()
+    # -i argument retained for backward incompatibility,
+    #  not used anymore
     parser.add_option('-i', '--ink',
                       default='/Applications/Inkscape.app/Contents/Resources/bin/inkscape',
                       dest='inkscape',
-                      help='Path to Inkscape')
+                      help='[deprecated] Path to Inkscape')
     parser.add_option('-b', '--badge',
                       default=None, dest='badge_type', help='Type of badge')
     parser.add_option('-r', '--root',
@@ -82,7 +81,6 @@ def parse_args():
                       default=None, dest='csv_file', help='CSV file')
 
     args, extras = parser.parse_args()
-    check(args.inkscape is not None, 'Path to Inkscape not given')
     check(args.root_dir is not None, 'Must specify root directory')
     msg = 'Must specify either CSV file or both root directory and user ID'
     if args.csv_file is not None:
@@ -126,14 +124,14 @@ def process_csv(args):
                 args.params['date'] = date.strftime(d, DATE_FORMAT)
             template_path = construct_template_path(args.root_dir, badge_type)
             output_path = construct_output_path(args.root_dir, badge_type, user_id)
-            create_certificate(args.inkscape, template_path, output_path, args.params)
+            create_certificate(template_path, output_path, args.params)
 
 def process_single(args):
     '''Process a single entry.'''
 
     template_path = construct_template_path(args.root_dir, args.badge_type)
     output_path = construct_output_path(args.root_dir, args.badge_type, args.user_id)
-    create_certificate(args.inkscape, template_path, output_path, args.params)
+    create_certificate(template_path, output_path, args.params)
 
 
 def construct_template_path(root_dir, badge_type):
@@ -148,7 +146,7 @@ def construct_output_path(root_dir, badge_type, user_id):
     return os.path.join(root_dir, badge_type, user_id + '.pdf')
 
 
-def create_certificate(inkscape_path, template_path, output_path, params):
+def create_certificate(template_path, output_path, params):
     '''Create a single certificate.'''
 
     with open(template_path, 'r') as reader:


### PR DESCRIPTION
**Problem**

The current script relies on Inkscape to convert SVGs to PDF.
As @gvwilson says [here](https://github.com/swcarpentry/amy/issues/656):
> I still really dislike the need for Inkscape for SVG-to-PDF conversion, but don't have anything better.

**Solution**
Use [CairoSVG](http://cairosvg.org/), which is a python module, instead of Inkscape.

I've tested the script, and it works well. Only cairosvg needs to be installed on the machine via `pip install cairosvg`.
Before continuing further, I would like your inputs on whether I'm going the right way. That'll be really helpful. Thanks!